### PR TITLE
전남대 BE_임강범 4주차 과제 (1단계)

### DIFF
--- a/src/main/java/gift/domain/category/controller/CategoryController.java
+++ b/src/main/java/gift/domain/category/controller/CategoryController.java
@@ -1,0 +1,56 @@
+package gift.domain.category.controller;
+
+import gift.domain.category.dto.CategoryRequest;
+import gift.domain.category.dto.CategoryResponse;
+import gift.domain.category.service.CategoryService;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/categories")
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping()
+    public ResponseEntity<Page<CategoryResponse>> getAllCategories(
+        @RequestParam(defaultValue = "0") int pageNo,
+        @RequestParam(defaultValue = "10") int pageSize
+    ){
+        Page<CategoryResponse> categoryPage = categoryService.getAllCategories(pageNo, pageSize);
+
+        return new ResponseEntity<>(categoryPage,HttpStatus.OK);
+    }
+
+    @PostMapping()
+    public ResponseEntity<CategoryResponse> createCategory(@RequestBody CategoryRequest request){
+        CategoryResponse response = categoryService.createCategory(request);
+
+        return new ResponseEntity<>(response,HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<CategoryResponse> updateCategory(@PathVariable("id") Long id, @RequestBody CategoryRequest request){
+        CategoryResponse response = categoryService.updateCategory(id, request);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable("id") Long id){
+        categoryService.deleteCategory(id);
+        return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/gift/domain/category/dto/CategoryRequest.java
+++ b/src/main/java/gift/domain/category/dto/CategoryRequest.java
@@ -10,7 +10,7 @@ public class CategoryRequest {
 
     private String description;
 
-    public CategoryRequest(){}
+    private CategoryRequest(){}
 
     public CategoryRequest(String name, String color, String imageUrl, String description) {
         this.name = name;

--- a/src/main/java/gift/domain/category/dto/CategoryRequest.java
+++ b/src/main/java/gift/domain/category/dto/CategoryRequest.java
@@ -1,0 +1,37 @@
+package gift.domain.category.dto;
+
+public class CategoryRequest {
+
+    private String name;
+
+    private String color;
+
+    private String imageUrl;
+
+    private String description;
+
+    public CategoryRequest(){}
+
+    public CategoryRequest(String name, String color, String imageUrl, String description) {
+        this.name = name;
+        this.color = color;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/gift/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/gift/domain/category/dto/CategoryResponse.java
@@ -1,0 +1,42 @@
+package gift.domain.category.dto;
+
+public class CategoryResponse {
+    private Long id;
+
+    private String name;
+
+    private String color;
+
+    private String imageUrl;
+
+    private String description;
+
+    public CategoryResponse(Long id, String name, String color, String imageUrl,
+        String description) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/gift/domain/category/entity/Category.java
+++ b/src/main/java/gift/domain/category/entity/Category.java
@@ -1,0 +1,68 @@
+package gift.domain.category.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Column
+    private String color;
+
+    @Column
+    private String imageUrl;
+
+    @Column
+    private String description;
+
+    protected Category() {
+    }
+
+    public Category(String name, String color, String imageUrl, String description) {
+        this(null, name, color, imageUrl, description);
+    }
+
+    public Category(Long id, String name, String color, String imageUrl, String description) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void updateAll(String name, String color, String imageUrl, String description){
+        this.name = name;
+        this.color = color;
+        this.imageUrl = imageUrl;
+        this.description = description;
+    }
+}

--- a/src/main/java/gift/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/gift/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package gift.domain.category.repository;
+
+import gift.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/src/main/java/gift/domain/category/service/CategoryService.java
+++ b/src/main/java/gift/domain/category/service/CategoryService.java
@@ -1,0 +1,55 @@
+package gift.domain.category.service;
+
+import gift.domain.category.dto.CategoryRequest;
+import gift.domain.category.dto.CategoryResponse;
+import gift.domain.category.entity.Category;
+import gift.domain.category.repository.CategoryRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(CategoryRepository categoryRepository) {
+        this.categoryRepository = categoryRepository;
+    }
+
+    public Page<CategoryResponse> getAllCategories(int pageNo, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize);
+
+        return categoryRepository.findAll(pageable).map(this::entityToDto);
+    }
+
+    public CategoryResponse createCategory(CategoryRequest request) {
+        Category savedCategory = categoryRepository.save(dtoToEntity(request));
+        return entityToDto(savedCategory);
+    }
+
+    public CategoryResponse updateCategory(Long id, CategoryRequest request) {
+        Category savedCategory = categoryRepository.findById(id).orElseThrow();
+        savedCategory.updateAll(request.getName(), request.getColor(), request.getImageUrl(),
+            request.getDescription());
+
+        Category updatedCategory = categoryRepository.save(savedCategory);
+
+        return entityToDto(updatedCategory);
+    }
+
+    public void deleteCategory(Long id){
+        Category savedCategory = categoryRepository.findById(id).orElseThrow();
+        categoryRepository.delete(savedCategory);
+    }
+
+    private CategoryResponse entityToDto(Category category) {
+        return new CategoryResponse(category.getId(), category.getName(), category.getColor(), category.getImageUrl(), category.getDescription());
+    }
+
+    private Category dtoToEntity(CategoryRequest request) {
+        return new Category(request.getName(), request.getColor(), request.getImageUrl(), request.getDescription());
+    }
+
+}

--- a/src/main/java/gift/domain/category/service/CategoryService.java
+++ b/src/main/java/gift/domain/category/service/CategoryService.java
@@ -8,7 +8,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @Service
 public class CategoryService {
 

--- a/src/main/java/gift/domain/member/dto/MemberRequest.java
+++ b/src/main/java/gift/domain/member/dto/MemberRequest.java
@@ -5,7 +5,7 @@ public class MemberRequest {
     String email;
     String password;
 
-    public MemberRequest() {
+    private MemberRequest() {
     }
 
     public MemberRequest(String email, String password) {

--- a/src/main/java/gift/domain/member/entity/Member.java
+++ b/src/main/java/gift/domain/member/entity/Member.java
@@ -4,6 +4,7 @@ import gift.domain.wishlist.entity.Wish;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -26,7 +27,7 @@ public class Member {
     @Column
     private String password;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "member", cascade = CascadeType.ALL)
     private List<Wish> wishList;
 
     protected Member() {

--- a/src/main/java/gift/domain/member/service/MemberService.java
+++ b/src/main/java/gift/domain/member/service/MemberService.java
@@ -10,7 +10,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @Service
 public class MemberService {
 

--- a/src/main/java/gift/domain/product/controller/ProductController.java
+++ b/src/main/java/gift/domain/product/controller/ProductController.java
@@ -30,7 +30,7 @@ public class ProductController {
     }
 
     @GetMapping()
-    public ResponseEntity<Page<ProductResponse>> readAll(
+    public ResponseEntity<Page<ProductResponse>> getAllProducts(
         @RequestParam(defaultValue = "0") int pageNo,
         @RequestParam(defaultValue = "10") int pageSize
     ) {
@@ -38,19 +38,18 @@ public class ProductController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ProductResponse> read(@PathVariable("id") Long id) {
+    public ResponseEntity<ProductResponse> getProduct(@PathVariable("id") Long id) {
         return new ResponseEntity<>(productService.getProduct(id), HttpStatus.OK);
     }
 
     @PostMapping()
-    public ResponseEntity<ProductResponse> create(
-        @RequestBody @Valid ProductRequest productRequest) {
-        ProductResponse productResponse = productService.addProduct(productRequest);
+    public ResponseEntity<ProductResponse> createProduct(@RequestBody @Valid ProductRequest productRequest) {
+        ProductResponse productResponse = productService.createProduct(productRequest);
         return new ResponseEntity<>(productResponse, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ProductResponse> update(@PathVariable("id") Long id,
+    public ResponseEntity<ProductResponse> updateProduct(@PathVariable("id") Long id,
         @RequestBody @Valid ProductRequest productRequest) {
         ProductResponse productResponse = productService.updateProduct(id, productRequest);
 
@@ -58,7 +57,7 @@ public class ProductController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ProductResponse> delete(@PathVariable("id") Long id) {
+    public ResponseEntity<ProductResponse> deleteProduct(@PathVariable("id") Long id) {
         productService.deleteProduct(id);
         return new ResponseEntity<>(null, HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/gift/domain/product/controller/ProductViewController.java
+++ b/src/main/java/gift/domain/product/controller/ProductViewController.java
@@ -44,7 +44,7 @@ public class ProductViewController {
     @PostMapping("/create-product")
     public String create(@ModelAttribute @Valid ProductRequest productRequest) {
 
-        productService.addProduct(productRequest);
+        productService.createProduct(productRequest);
         return "redirect:/";
     }
 

--- a/src/main/java/gift/domain/product/dto/ProductRequest.java
+++ b/src/main/java/gift/domain/product/dto/ProductRequest.java
@@ -22,7 +22,7 @@ public class ProductRequest {
 
     private Long categoryId;
 
-    public ProductRequest() {
+    private ProductRequest() {
     }
 
     public ProductRequest(String name, int price, String imageUrl, Long categoryId) {

--- a/src/main/java/gift/domain/product/dto/ProductRequest.java
+++ b/src/main/java/gift/domain/product/dto/ProductRequest.java
@@ -20,13 +20,16 @@ public class ProductRequest {
     @NotNull
     private String imageUrl;
 
+    private Long categoryId;
+
     public ProductRequest() {
     }
 
-    public ProductRequest(String name, int price, String imageUrl) {
+    public ProductRequest(String name, int price, String imageUrl, Long categoryId) {
         this.name = name;
         this.price = price;
         this.imageUrl = imageUrl;
+        this.categoryId = categoryId;
     }
 
     public String getName() {
@@ -39,5 +42,8 @@ public class ProductRequest {
 
     public String getImageUrl() {
         return imageUrl;
+    }
+    public Long getCategoryId() {
+        return categoryId;
     }
 }

--- a/src/main/java/gift/domain/product/dto/ProductResponse.java
+++ b/src/main/java/gift/domain/product/dto/ProductResponse.java
@@ -6,19 +6,21 @@ public class ProductResponse {
     private String name;
     private int price;
     private String imageUrl;
+    private Long categoryId;
 
     public ProductResponse() {
     }
 
-    public ProductResponse(String name, int price, String imageUrl) {
-        this(null, name, price, imageUrl);
+    public ProductResponse(String name, int price, String imageUrl, Long categoryId) {
+        this(null, name, price, imageUrl, categoryId);
     }
 
-    public ProductResponse(Long id, String name, int price, String imageUrl) {
+    public ProductResponse(Long id, String name, int price, String imageUrl, Long categoryId) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.imageUrl = imageUrl;
+        this.categoryId = categoryId;
     }
 
     public Long getId() {
@@ -35,5 +37,9 @@ public class ProductResponse {
 
     public String getImageUrl() {
         return this.imageUrl;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
     }
 }

--- a/src/main/java/gift/domain/product/entity/Product.java
+++ b/src/main/java/gift/domain/product/entity/Product.java
@@ -2,12 +2,15 @@ package gift.domain.product.entity;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import gift.domain.category.entity.Category;
 import gift.domain.wishlist.entity.Wish;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
@@ -30,22 +33,27 @@ public class Product {
     @Column
     private String imageUrl;
 
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private Category category;
+
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
     private List<Wish> wishList;
 
     protected Product() {
     }
 
-    public Product(String name, int price, String imageUrl) {
-        this(null, name, price, imageUrl);
+    public Product(String name, int price, String imageUrl, Category category) {
+        this(null, name, price, imageUrl, category);
     }
 
-    public Product(Long id, String name, int price, String imageUrl) {
+    public Product(Long id, String name, int price, String imageUrl, Category category) {
         this.id = id;
         this.name = name;
         this.price = price;
         this.imageUrl = imageUrl;
         this.wishList = new ArrayList<>();
+        this.category = category;
     }
 
     public Long getId() {
@@ -68,10 +76,19 @@ public class Product {
         return wishList;
     }
 
-    public void update(String name, int price, String imageUrl) {
+    public Category getCategory() {
+        return category;
+    }
+
+    public void updateAll(String name, int price, String imageUrl, Category category) {
         this.name = name;
         this.price = price;
         this.imageUrl = imageUrl;
+        this.category = category;
+    }
+
+    public void updateCategory(Category category){
+        this.category = category;
     }
 
     public void removeWish(Wish wish) {

--- a/src/main/java/gift/domain/product/entity/Product.java
+++ b/src/main/java/gift/domain/product/entity/Product.java
@@ -3,18 +3,13 @@ package gift.domain.product.entity;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 import gift.domain.category.entity.Category;
-import gift.domain.wishlist.entity.Wish;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "product")
@@ -37,9 +32,6 @@ public class Product {
     @JoinColumn(name = "category_id")
     private Category category;
 
-    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)
-    private List<Wish> wishList;
-
     protected Product() {
     }
 
@@ -52,7 +44,6 @@ public class Product {
         this.name = name;
         this.price = price;
         this.imageUrl = imageUrl;
-        this.wishList = new ArrayList<>();
         this.category = category;
     }
 
@@ -72,10 +63,6 @@ public class Product {
         return imageUrl;
     }
 
-    public List<Wish> getWishList() {
-        return wishList;
-    }
-
     public Category getCategory() {
         return category;
     }
@@ -91,7 +78,4 @@ public class Product {
         this.category = category;
     }
 
-    public void removeWish(Wish wish) {
-        this.wishList.remove(wish);
-    }
 }

--- a/src/main/java/gift/domain/product/service/ProductService.java
+++ b/src/main/java/gift/domain/product/service/ProductService.java
@@ -1,11 +1,12 @@
 package gift.domain.product.service;
 
+import gift.domain.category.entity.Category;
+import gift.domain.category.repository.CategoryRepository;
 import gift.domain.product.dto.ProductRequest;
 import gift.domain.product.dto.ProductResponse;
 import gift.domain.product.entity.Product;
 import gift.domain.product.repository.ProductRepository;
 import jakarta.persistence.EntityNotFoundException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,10 +16,12 @@ import org.springframework.stereotype.Service;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final CategoryRepository categoryRepository;
 
-    @Autowired
-    public ProductService(ProductRepository productRepository) {
+    public ProductService(ProductRepository productRepository,
+        CategoryRepository categoryRepository) {
         this.productRepository = productRepository;
+        this.categoryRepository = categoryRepository;
     }
 
     public ProductResponse getProduct(Long id) {
@@ -33,8 +36,9 @@ public class ProductService {
         return productRepository.findAll(pageable).map(this::entityToDto);
     }
 
-    public ProductResponse addProduct(ProductRequest productRequest) {
-        Product product = productRepository.save(dtoToEntity(productRequest));
+    public ProductResponse createProduct(ProductRequest productRequest) {
+        Category savedCategory = categoryRepository.findById(productRequest.getCategoryId()).orElseThrow();
+        Product product = productRepository.save(dtoToEntity(productRequest, savedCategory));
         return entityToDto(product);
     }
 
@@ -43,8 +47,10 @@ public class ProductService {
             .findById(id)
             .orElseThrow(() -> new EntityNotFoundException("not found entity"));
 
-        product.update(productRequest.getName(), productRequest.getPrice(),
-            productRequest.getImageUrl());
+        Category savedCategory = categoryRepository.findById(productRequest.getCategoryId()).orElseThrow();
+
+        product.updateAll(productRequest.getName(), productRequest.getPrice(),
+            productRequest.getImageUrl(), savedCategory);
 
         return entityToDto(productRepository.save(product));
 
@@ -59,12 +65,13 @@ public class ProductService {
 
     private ProductResponse entityToDto(Product product) {
         return new ProductResponse(product.getId(), product.getName(), product.getPrice(),
-            product.getImageUrl());
+            product.getImageUrl(), product.getCategory().getId());
     }
 
-    private Product dtoToEntity(ProductRequest productRequest) {
+    private Product dtoToEntity(ProductRequest productRequest, Category category) {
+
         return new Product(productRequest.getName(), productRequest.getPrice(),
-            productRequest.getImageUrl());
+            productRequest.getImageUrl(), category);
     }
 
 }

--- a/src/main/java/gift/domain/product/service/ProductService.java
+++ b/src/main/java/gift/domain/product/service/ProductService.java
@@ -11,7 +11,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @Service
 public class ProductService {
 

--- a/src/main/java/gift/domain/wishlist/controller/WishController.java
+++ b/src/main/java/gift/domain/wishlist/controller/WishController.java
@@ -38,7 +38,7 @@ public class WishController {
     public ResponseEntity<WishResponse> createWish(@RequestBody ProductIdRequest productIdRequest,
         @LoginMember Member member) {
         WishRequest wishRequest = new WishRequest(member.getId(), productIdRequest.getProductId());
-        WishResponse wishResponse = wishService.addWish(wishRequest);
+        WishResponse wishResponse = wishService.createWish(wishRequest);
 
         return new ResponseEntity<>(wishResponse, HttpStatus.CREATED);
     }

--- a/src/main/java/gift/domain/wishlist/dto/ProductIdRequest.java
+++ b/src/main/java/gift/domain/wishlist/dto/ProductIdRequest.java
@@ -4,7 +4,7 @@ public class ProductIdRequest {
 
     private Long productId;
 
-    public ProductIdRequest() {
+    private ProductIdRequest() {
     }
 
     public ProductIdRequest(Long productId) {

--- a/src/main/java/gift/domain/wishlist/dto/WishRequest.java
+++ b/src/main/java/gift/domain/wishlist/dto/WishRequest.java
@@ -6,7 +6,7 @@ public class WishRequest {
 
     private Long productId;
 
-    public WishRequest() {
+    private WishRequest() {
     }
 
     public WishRequest(Long memberId, Long productId) {

--- a/src/main/java/gift/domain/wishlist/entity/Wish.java
+++ b/src/main/java/gift/domain/wishlist/entity/Wish.java
@@ -19,11 +19,11 @@ public class Wish {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "product_id")
     private Product product;
 
@@ -40,7 +40,6 @@ public class Wish {
         this.product = product;
 
         member.getWishList().add(this);
-        product.getWishList().add(this);
     }
 
     public Long getId() {
@@ -60,12 +59,5 @@ public class Wish {
         this.member.getWishList().remove(this);
         this.member = member;
         member.getWishList().add(this);
-    }
-
-    public void updateProduct(Product product) {
-        // 기존 productEntity에서 wishEntity 삭제
-        this.product.getWishList().remove(this);
-        this.product = product;
-        product.getWishList().add(this);
     }
 }

--- a/src/main/java/gift/domain/wishlist/service/WishService.java
+++ b/src/main/java/gift/domain/wishlist/service/WishService.java
@@ -38,7 +38,7 @@ public class WishService {
             .map(this::entityToDto);
     }
 
-    public WishResponse addWish(WishRequest wishRequest) {
+    public WishResponse createWish(WishRequest wishRequest) {
         Wish wish = DtoToEntity(wishRequest);
 
         return entityToDto(wishRepository.save(wish));
@@ -51,7 +51,6 @@ public class WishService {
 
         if (wish.getMember().getId().equals(member.getId())) {
             wish.getMember().removeWish(wish);
-            wish.getProduct().removeWish(wish);
             wishRepository.delete(wish);
         }
     }

--- a/src/test/java/gift/controller/MemberControllerTest.java
+++ b/src/test/java/gift/controller/MemberControllerTest.java
@@ -49,7 +49,7 @@ class MemberControllerTest {
 
     @Test
     @DisplayName("로그인 성공 E2E 테스트")
-    void loginSuccess() {
+    void loginSuccessTest() {
         var request = new MemberRequest("test@google.co.kr", "password");
         var url = "http://localhost:" + port + "/api/members/login";
         var requestEntity = new RequestEntity<>(request, HttpMethod.POST, URI.create(url));
@@ -60,7 +60,7 @@ class MemberControllerTest {
 
     @Test
     @DisplayName("로그인 실패 E2E 테스트")
-    void loginFail() {
+    void loginFailTest() {
         var request = new MemberRequest("test@google.co.kr", "wrong-password");
         var url = "http://localhost:" + port + "/api/members/login";
         var requestEntity = new RequestEntity<>(request, HttpMethod.POST, URI.create(url));

--- a/src/test/java/gift/controller/ProductControllerTest.java
+++ b/src/test/java/gift/controller/ProductControllerTest.java
@@ -2,6 +2,7 @@ package gift.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gift.domain.category.entity.Category;
 import gift.domain.product.dto.ProductRequest;
 import gift.domain.product.entity.Product;
 import gift.domain.product.repository.ProductRepository;
@@ -45,7 +46,8 @@ class ProductControllerTest {
 
     @Test
     void read() {
-        Product product = productRepository.save(new Product("test", 1000, "test.jpg"));
+        Category savedCategory = new Category(1L, "test", "color", "image", "description");
+        Product product = productRepository.save(new Product("test", 1000, "test.jpg", savedCategory));
         System.out.println("테스트" + product.getName() + "id 값" + product.getId());
 
         var url = "http://localhost:" + port + "/api/products/1";
@@ -58,7 +60,7 @@ class ProductControllerTest {
     @Test
     @DisplayName("Product 생성 API 테스트")
     void create() {
-        var request = new ProductRequest("product", 1000, "image.jpg");
+        var request = new ProductRequest("product", 1000, "image.jpg", 1L);
         var url = "http://localhost:" + port + "/api/products";
         var requestEntity = new RequestEntity<>(request, HttpMethod.POST, URI.create(url));
 
@@ -68,9 +70,10 @@ class ProductControllerTest {
 
     @Test
     void update() {
-        Product product = productRepository.save(new Product("test", 1000, "test.jpg"));
+        Category savedCategory = new Category(1L, "test", "color", "image", "description");
+        Product product = productRepository.save(new Product("test", 1000, "test.jpg", savedCategory));
         var id = 1L;
-        var request = new ProductRequest("product", 1000, "image.jpg");
+        var request = new ProductRequest("product", 1000, "image.jpg", 1L);
         var url = "http://localhost:" + port + "/api/products/" + id;
         var requestEntity = new RequestEntity<>(request, HttpMethod.PUT, URI.create(url));
 
@@ -80,7 +83,8 @@ class ProductControllerTest {
 
     @Test
     void delete() {
-        Product product = productRepository.save(new Product("test", 1000, "test.jpg"));
+        Category savedCategory = new Category(1L, "test", "color", "image", "description");
+        Product product = productRepository.save(new Product("test", 1000, "test.jpg", savedCategory));
         var id = 1L;
         var url = "http://localhost:" + port + "/api/products/" + id;
 

--- a/src/test/java/gift/controller/ProductControllerTest.java
+++ b/src/test/java/gift/controller/ProductControllerTest.java
@@ -39,13 +39,9 @@ class ProductControllerTest {
     @Autowired
     private CategoryRepository categoryRepository;
 
-    @BeforeEach
-    void beforeEach(){
-
-    }
     @Test
     @DisplayName("상품 전체 조회 테스트")
-    void readAll() {
+    void getAllProductsTest() {
         var url = "http://localhost:" + port + "/api/products";
         var request = new RequestEntity<>(HttpMethod.GET, URI.create(url));
 
@@ -55,7 +51,7 @@ class ProductControllerTest {
 
     @Test
     @DisplayName("특정 상품 전체 조회 테스트")
-    void read() {
+    void getProductTest() {
         Category category = new Category("test", "color", "image", "description");
         Category savedCategory = categoryRepository.save(category);
 
@@ -71,7 +67,7 @@ class ProductControllerTest {
 
     @Test
     @DisplayName("상품 생성 테스트")
-    void create() {
+    void createProductTest() {
         Category category = new Category("test", "color", "image", "description");
         categoryRepository.save(category);
 
@@ -86,7 +82,7 @@ class ProductControllerTest {
 
     @Test
     @DisplayName("상품 업데이트 테스트")
-    void update() {
+    void updateProductTest() {
         Category category = new Category("test", "color", "image", "description");
         Category savedCategory = categoryRepository.save(category);
 
@@ -104,7 +100,7 @@ class ProductControllerTest {
 
     @Test
     @DisplayName("상품 삭제 테스트")
-    void delete() {
+    void deleteProductTest() {
         Category request = new Category("test", "color", "image", "description");
         Category savedCategory = categoryRepository.save(request);
 

--- a/src/test/java/gift/controller/ProductControllerTest.java
+++ b/src/test/java/gift/controller/ProductControllerTest.java
@@ -3,12 +3,12 @@ package gift.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import gift.domain.category.entity.Category;
+import gift.domain.category.repository.CategoryRepository;
 import gift.domain.product.dto.ProductRequest;
 import gift.domain.product.entity.Product;
 import gift.domain.product.repository.ProductRepository;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,8 +19,12 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 class ProductControllerTest {
 
     @LocalServerPort
@@ -32,10 +36,15 @@ class ProductControllerTest {
     @Autowired
     private ProductRepository productRepository;
 
-    @PersistenceContext
-    private EntityManager entityManager;
+    @Autowired
+    private CategoryRepository categoryRepository;
 
+    @BeforeEach
+    void beforeEach(){
+
+    }
     @Test
+    @DisplayName("상품 전체 조회 테스트")
     void readAll() {
         var url = "http://localhost:" + port + "/api/products";
         var request = new RequestEntity<>(HttpMethod.GET, URI.create(url));
@@ -45,10 +54,13 @@ class ProductControllerTest {
     }
 
     @Test
+    @DisplayName("특정 상품 전체 조회 테스트")
     void read() {
-        Category savedCategory = new Category(1L, "test", "color", "image", "description");
-        Product product = productRepository.save(new Product("test", 1000, "test.jpg", savedCategory));
-        System.out.println("테스트" + product.getName() + "id 값" + product.getId());
+        Category category = new Category("test", "color", "image", "description");
+        Category savedCategory = categoryRepository.save(category);
+
+        Product product = new Product("test", 1000, "test.jpg", savedCategory);
+        productRepository.save(product);
 
         var url = "http://localhost:" + port + "/api/products/1";
         var request = new RequestEntity<>(HttpMethod.GET, URI.create(url));
@@ -58,9 +70,13 @@ class ProductControllerTest {
     }
 
     @Test
-    @DisplayName("Product 생성 API 테스트")
+    @DisplayName("상품 생성 테스트")
     void create() {
+        Category category = new Category("test", "color", "image", "description");
+        categoryRepository.save(category);
+
         var request = new ProductRequest("product", 1000, "image.jpg", 1L);
+
         var url = "http://localhost:" + port + "/api/products";
         var requestEntity = new RequestEntity<>(request, HttpMethod.POST, URI.create(url));
 
@@ -69,11 +85,16 @@ class ProductControllerTest {
     }
 
     @Test
+    @DisplayName("상품 업데이트 테스트")
     void update() {
-        Category savedCategory = new Category(1L, "test", "color", "image", "description");
-        Product product = productRepository.save(new Product("test", 1000, "test.jpg", savedCategory));
+        Category category = new Category("test", "color", "image", "description");
+        Category savedCategory = categoryRepository.save(category);
+
+        Product product = new Product("test", 1000, "test.jpg", savedCategory);
+        productRepository.save(product);
+
         var id = 1L;
-        var request = new ProductRequest("product", 1000, "image.jpg", 1L);
+        var request = new ProductRequest("update", 1000, "image.jpg", 1L);
         var url = "http://localhost:" + port + "/api/products/" + id;
         var requestEntity = new RequestEntity<>(request, HttpMethod.PUT, URI.create(url));
 
@@ -82,9 +103,13 @@ class ProductControllerTest {
     }
 
     @Test
+    @DisplayName("상품 삭제 테스트")
     void delete() {
-        Category savedCategory = new Category(1L, "test", "color", "image", "description");
-        Product product = productRepository.save(new Product("test", 1000, "test.jpg", savedCategory));
+        Category request = new Category("test", "color", "image", "description");
+        Category savedCategory = categoryRepository.save(request);
+
+        productRepository.save(new Product("test", 1000, "test.jpg", savedCategory));
+
         var id = 1L;
         var url = "http://localhost:" + port + "/api/products/" + id;
 

--- a/src/test/java/gift/controller/RegisterTest.java
+++ b/src/test/java/gift/controller/RegisterTest.java
@@ -26,7 +26,7 @@ public class RegisterTest {
 
     @Test
     @DisplayName("회원가입 E2E 테스트")
-    void register() {
+    void registerTest() {
         var request = new MemberRequest("test@google.co.kr", "password");
         var url = "http://localhost:" + port + "/api/members/register";
         var requestEntity = new RequestEntity<>(request, HttpMethod.POST, URI.create(url));

--- a/src/test/java/gift/controller/WishControllerTest.java
+++ b/src/test/java/gift/controller/WishControllerTest.java
@@ -2,14 +2,19 @@ package gift.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import gift.domain.category.entity.Category;
+import gift.domain.category.repository.CategoryRepository;
 import gift.domain.member.dto.MemberRequest;
-import gift.domain.member.entity.Member;
+import gift.domain.product.entity.Product;
+import gift.domain.product.repository.ProductRepository;
 import gift.domain.wishlist.dto.ProductIdRequest;
 import gift.domain.wishlist.dto.WishRequest;
 import gift.domain.member.service.MemberService;
+import gift.domain.wishlist.repository.WishRepository;
 import gift.domain.wishlist.service.WishService;
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,9 +25,12 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 class WishControllerTest {
 
     @LocalServerPort
@@ -37,6 +45,15 @@ class WishControllerTest {
     @Autowired
     private WishService wishService;
 
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private WishRepository wishRepository;
+
     private String token;
 
     @BeforeEach
@@ -47,6 +64,7 @@ class WishControllerTest {
     }
 
     @Test
+    @DisplayName("위시리스트 전체 조회 테스트")
     void getWishesTest() {
         // given
         var url = "http://localhost:" + port + "/api/wishes";
@@ -59,13 +77,16 @@ class WishControllerTest {
 
         // then
         assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.OK);
-
-        Member member = memberService.getMemberFromToken(token);
-        memberService.deleteMember(member.getId());
     }
 
     @Test
+    @DisplayName("위시리스트 생성 테스트")
     void createWishTest() {
+        Category category = new Category("name", "color", "imageUrl", "description");
+        Category savedCategory = categoryRepository.save(category);
+
+        Product product = new Product("name", 1000, "imageUrl", savedCategory);
+        productRepository.save(product);
         // given
         var request = new ProductIdRequest(1L);
 
@@ -79,18 +100,19 @@ class WishControllerTest {
 
         // then
         assertThat(actual.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-
-        wishService.deleteWish(1L, memberService.getMemberFromToken(token));
-        Member member = memberService.getMemberFromToken(token);
-        memberService.deleteMember(member.getId());
     }
 
     @Test
+    @DisplayName("위시리스트 삭제 테스트")
     void deleteWishTest() {
+
         // given
-        // 테스트를 위한 wish 1개 생성
-        var request = new WishRequest(memberService.getMemberFromToken(token).getId(), 1L);
-        wishService.addWish(request);
+        Category category = new Category("name", "color", "imageUrl", "description");
+        Category savedCategory = categoryRepository.save(category);
+
+        Product product = new Product("name", 1000, "imageUrl", savedCategory);
+        productRepository.save(product);
+        wishService.createWish(new WishRequest(1L, 1L));
 
         var id = 1L;
         var url = "http://localhost:" + port + "/api/wishes/" + id;

--- a/src/test/java/gift/controller/WishControllerTest.java
+++ b/src/test/java/gift/controller/WishControllerTest.java
@@ -8,10 +8,9 @@ import gift.domain.member.dto.MemberRequest;
 import gift.domain.product.entity.Product;
 import gift.domain.product.repository.ProductRepository;
 import gift.domain.wishlist.dto.ProductIdRequest;
-import gift.domain.wishlist.dto.WishRequest;
 import gift.domain.member.service.MemberService;
+import gift.domain.wishlist.entity.Wish;
 import gift.domain.wishlist.repository.WishRepository;
-import gift.domain.wishlist.service.WishService;
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -41,9 +40,6 @@ class WishControllerTest {
 
     @Autowired
     private MemberService memberService;
-
-    @Autowired
-    private WishService wishService;
 
     @Autowired
     private CategoryRepository categoryRepository;
@@ -112,7 +108,9 @@ class WishControllerTest {
 
         Product product = new Product("name", 1000, "imageUrl", savedCategory);
         productRepository.save(product);
-        wishService.createWish(new WishRequest(1L, 1L));
+
+        Wish wish = new Wish(memberService.getMemberFromToken(token), product);
+        wishRepository.save(wish);
 
         var id = 1L;
         var url = "http://localhost:" + port + "/api/wishes/" + id;

--- a/src/test/java/gift/repository/CategoryRepositoryTest.java
+++ b/src/test/java/gift/repository/CategoryRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import gift.domain.category.dto.CategoryRequest;
-import gift.domain.category.dto.CategoryResponse;
 import gift.domain.category.entity.Category;
 import gift.domain.category.repository.CategoryRepository;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/gift/repository/CategoryRepositoryTest.java
+++ b/src/test/java/gift/repository/CategoryRepositoryTest.java
@@ -1,0 +1,79 @@
+package gift.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import gift.domain.category.dto.CategoryRequest;
+import gift.domain.category.dto.CategoryResponse;
+import gift.domain.category.entity.Category;
+import gift.domain.category.repository.CategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class CategoryRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+    
+    @Test
+    @DisplayName("findById 테스트")
+    void findById() {
+        // given
+        CategoryRequest request = new CategoryRequest("test", "color", "imageUrl", "description");
+        
+        Category expected = categoryRepository.save(dtoToEntity(request));
+
+        // when
+        Category actual = categoryRepository.findById(expected.getId()).orElseThrow();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("save 테스트")
+    void save() {
+        // given
+        CategoryRequest request = new CategoryRequest("test", "color", "imageUrl", "description");
+        
+        Category expected = dtoToEntity(request);
+
+        // when
+        Category actual = categoryRepository.save(expected);
+
+        // then
+        assertAll(
+            () -> assertThat(actual.getId()).isNotNull(),
+            () -> assertThat(actual.getName()).isEqualTo(expected.getName()),
+            () -> assertThat(actual.getColor()).isEqualTo(expected.getColor()),
+            () -> assertThat(actual.getImageUrl()).isEqualTo(expected.getImageUrl()),
+            () -> assertThat(actual.getDescription()).isEqualTo(expected.getDescription())
+        );
+    }
+
+    @Test
+    @DisplayName("delete 테스트")
+    void delete() {
+        // given
+        CategoryRequest request = new CategoryRequest("test", "color", "imageUrl", "description");
+        Category savedCategory = categoryRepository.save(dtoToEntity(request));
+
+        // when
+        categoryRepository.delete(savedCategory);
+
+        // then
+        assertTrue(categoryRepository.findById(savedCategory.getId()).isEmpty());
+    }
+
+    private CategoryResponse entityToDto(Category category) {
+        return new CategoryResponse(category.getId(), category.getName(), category.getColor(), category.getImageUrl(), category.getDescription());
+    }
+
+    private Category dtoToEntity(CategoryRequest request) {
+        return new Category(request.getName(), request.getColor(), request.getImageUrl(), request.getDescription());
+    }
+}

--- a/src/test/java/gift/repository/CategoryRepositoryTest.java
+++ b/src/test/java/gift/repository/CategoryRepositoryTest.java
@@ -21,7 +21,7 @@ public class CategoryRepositoryTest {
     
     @Test
     @DisplayName("findById 테스트")
-    void findById() {
+    void findByIdTest() {
         // given
         CategoryRequest request = new CategoryRequest("test", "color", "imageUrl", "description");
         
@@ -36,7 +36,7 @@ public class CategoryRepositoryTest {
 
     @Test
     @DisplayName("save 테스트")
-    void save() {
+    void saveTest() {
         // given
         CategoryRequest request = new CategoryRequest("test", "color", "imageUrl", "description");
         
@@ -57,7 +57,7 @@ public class CategoryRepositoryTest {
 
     @Test
     @DisplayName("delete 테스트")
-    void delete() {
+    void deleteTest() {
         // given
         CategoryRequest request = new CategoryRequest("test", "color", "imageUrl", "description");
         Category savedCategory = categoryRepository.save(dtoToEntity(request));
@@ -67,10 +67,6 @@ public class CategoryRepositoryTest {
 
         // then
         assertTrue(categoryRepository.findById(savedCategory.getId()).isEmpty());
-    }
-
-    private CategoryResponse entityToDto(Category category) {
-        return new CategoryResponse(category.getId(), category.getName(), category.getColor(), category.getImageUrl(), category.getDescription());
     }
 
     private Category dtoToEntity(CategoryRequest request) {

--- a/src/test/java/gift/repository/MemberRepositoryTest.java
+++ b/src/test/java/gift/repository/MemberRepositoryTest.java
@@ -19,7 +19,7 @@ class MemberRepositoryTest {
 
     @Test
     @DisplayName("findByEmail 테스트")
-    void findByEmail() {
+    void findByEmailTest() {
         // given
         MemberRequest request = new MemberRequest("test@google.co.kr", "password");
         Member expected = memberRepository.save(
@@ -34,7 +34,7 @@ class MemberRepositoryTest {
 
     @Test
     @DisplayName("findById 테스트")
-    void findById() {
+    void findByIdTest() {
         // given
         MemberRequest request = new MemberRequest("test@google.co.kr", "password");
         Member expected = memberRepository.save(
@@ -49,7 +49,7 @@ class MemberRepositoryTest {
 
     @Test
     @DisplayName("save 테스트")
-    void save() {
+    void saveTest() {
         // given
         MemberRequest request = new MemberRequest("test@google.co.kr", "password");
         Member expected = new Member(request.getEmail(), request.getPassword());
@@ -67,7 +67,7 @@ class MemberRepositoryTest {
 
     @Test
     @DisplayName("delete 테스트")
-    void delete() {
+    void deleteTest() {
         // given
         MemberRequest request = new MemberRequest("test@google.co.kr", "password");
         Member savedMember = memberRepository.save(

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -24,7 +24,7 @@ class ProductRepositoryTest {
 
     @Test
     @DisplayName("findById 테스트")
-    void findById() {
+    void findByIdTest() {
         // given
         ProductRequest request = new ProductRequest("test", 1000, "test.jpg", 1L);
         Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
@@ -39,7 +39,7 @@ class ProductRepositoryTest {
 
     @Test
     @DisplayName("save 테스트")
-    void save() {
+    void saveTest() {
         // given
         ProductRequest request = new ProductRequest("test", 1000, "test.jpg", 1L);
         Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
@@ -62,7 +62,7 @@ class ProductRepositoryTest {
 
     @Test
     @DisplayName("delete 테스트")
-    void delete() {
+    void deleteTest() {
         // given
         ProductRequest request = new ProductRequest("test", 1000, "test.jpg", 1L);
         Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));

--- a/src/test/java/gift/repository/ProductRepositoryTest.java
+++ b/src/test/java/gift/repository/ProductRepositoryTest.java
@@ -3,7 +3,8 @@ package gift.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-import gift.domain.product.dto.ProductResponse;
+import gift.domain.category.entity.Category;
+import gift.domain.category.repository.CategoryRepository;
 import gift.domain.product.repository.ProductRepository;
 import gift.domain.product.dto.ProductRequest;
 import gift.domain.product.entity.Product;
@@ -18,16 +19,16 @@ class ProductRepositoryTest {
     @Autowired
     private ProductRepository productRepository;
 
-    @Test
-    void findByName() {
-    }
+    @Autowired
+    private CategoryRepository categoryRepository;
 
     @Test
     @DisplayName("findById 테스트")
     void findById() {
         // given
-        ProductRequest request = new ProductRequest("test", 1000, "test.jpg");
-        Product expected = productRepository.save(dtoToEntity(request));
+        ProductRequest request = new ProductRequest("test", 1000, "test.jpg", 1L);
+        Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
+        Product expected = productRepository.save(dtoToEntity(request, savedCategory));
 
         // when
         Product actual = productRepository.findById(expected.getId()).orElseThrow();
@@ -40,9 +41,11 @@ class ProductRepositoryTest {
     @DisplayName("save 테스트")
     void save() {
         // given
-        ProductRequest request = new ProductRequest("test", 1000, "test.jpg");
+        ProductRequest request = new ProductRequest("test", 1000, "test.jpg", 1L);
+        Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
+
         Product expected = new Product(request.getName(), request.getPrice(),
-            request.getImageUrl());
+            request.getImageUrl(), savedCategory);
 
         // when
         Product actual = productRepository.save(expected);
@@ -52,7 +55,8 @@ class ProductRepositoryTest {
             () -> assertThat(actual.getId()).isNotNull(),
             () -> assertThat(actual.getName()).isEqualTo(expected.getName()),
             () -> assertThat(actual.getPrice()).isEqualTo(expected.getPrice()),
-            () -> assertThat(actual.getImageUrl()).isEqualTo(expected.getImageUrl())
+            () -> assertThat(actual.getImageUrl()).isEqualTo(expected.getImageUrl()),
+            () -> assertThat(actual.getCategory().getId()).isEqualTo(expected.getCategory().getId())
         );
     }
 
@@ -60,8 +64,9 @@ class ProductRepositoryTest {
     @DisplayName("delete 테스트")
     void delete() {
         // given
-        ProductRequest request = new ProductRequest("test", 1000, "test.jpg");
-        Product savedProduct = productRepository.save(dtoToEntity(request));
+        ProductRequest request = new ProductRequest("test", 1000, "test.jpg", 1L);
+        Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
+        Product savedProduct = productRepository.save(dtoToEntity(request, savedCategory));
 
         // when
         productRepository.delete(savedProduct);
@@ -70,9 +75,9 @@ class ProductRepositoryTest {
         assertTrue(productRepository.findById(savedProduct.getId()).isEmpty());
     }
 
-    private Product dtoToEntity(ProductRequest productRequest) {
+    private Product dtoToEntity(ProductRequest productRequest, Category savedCategory) {
         return new Product(productRequest.getName(), productRequest.getPrice(),
-            productRequest.getImageUrl());
+            productRequest.getImageUrl(), savedCategory);
     }
 
 }

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -3,6 +3,8 @@ package gift.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import gift.domain.category.entity.Category;
+import gift.domain.category.repository.CategoryRepository;
 import gift.domain.member.entity.Member;
 import gift.domain.member.repository.MemberRepository;
 import gift.domain.product.entity.Product;
@@ -29,15 +31,18 @@ class WishRepositoryTest {
     @Autowired
     private ProductRepository productRepository;
 
+    @Autowired
+    private CategoryRepository categoryRepository;
+
     @Test
     @DisplayName("memberId로 wish 리스트 가져오는 findAllByMember 테스트")
     void findAllByMemberEntity() {
         // given
         Member requestMember = new Member("test", "password");
         Member savedMember = memberRepository.save(requestMember);
-
-        Product requestProduct1 = new Product("product1", 1000, "product1.jpg");
-        Product requestProduct2 = new Product("product2", 2000, "product2.jpg");
+        Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
+        Product requestProduct1 = new Product("product1", 1000, "product1.jpg", savedCategory);
+        Product requestProduct2 = new Product("product2", 2000, "product2.jpg", savedCategory);
         Product savedProduct1 = productRepository.save(requestProduct1);
         Product savedProduct2 = productRepository.save(requestProduct2);
 
@@ -64,7 +69,8 @@ class WishRepositoryTest {
         Member requestMember = new Member("test", "password");
         Member savedMember = memberRepository.save(requestMember);
 
-        Product requestProduct = new Product("product", 1000, "product1.jpg");
+        Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
+        Product requestProduct = new Product("product", 1000, "product1.jpg", savedCategory);
         Product savedProduct = productRepository.save(requestProduct);
 
         Wish requestWish = new Wish(savedMember, savedProduct);
@@ -84,7 +90,8 @@ class WishRepositoryTest {
         Member requestMember = new Member("test", "password");
         Member savedMember = memberRepository.save(requestMember);
 
-        Product requestProduct = new Product("product", 1000, "product1.jpg");
+        Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
+        Product requestProduct = new Product("product", 1000, "product1.jpg",savedCategory);
         Product savedProduct = productRepository.save(requestProduct);
 
         Wish expected = new Wish(savedMember, savedProduct);
@@ -107,7 +114,8 @@ class WishRepositoryTest {
         Member requestMember = new Member("test", "password");
         Member savedMember = memberRepository.save(requestMember);
 
-        Product requestProduct = new Product("product", 1000, "product1.jpg");
+        Category savedCategory = categoryRepository.save(new Category("test", "color", "image", "description"));
+        Product requestProduct = new Product("product", 1000, "product1.jpg",savedCategory);
         Product savedProduct = productRepository.save(requestProduct);
 
         Wish request = new Wish(savedMember, savedProduct);

--- a/src/test/java/gift/repository/WishRepositoryTest.java
+++ b/src/test/java/gift/repository/WishRepositoryTest.java
@@ -36,7 +36,7 @@ class WishRepositoryTest {
 
     @Test
     @DisplayName("memberId로 wish 리스트 가져오는 findAllByMember 테스트")
-    void findAllByMemberEntity() {
+    void findAllByMemberEntityTest() {
         // given
         Member requestMember = new Member("test", "password");
         Member savedMember = memberRepository.save(requestMember);
@@ -64,7 +64,7 @@ class WishRepositoryTest {
 
     @Test
     @DisplayName("findById 테스트")
-    void findById() {
+    void findByIdTest() {
         // given
         Member requestMember = new Member("test", "password");
         Member savedMember = memberRepository.save(requestMember);
@@ -85,7 +85,7 @@ class WishRepositoryTest {
 
     @Test
     @DisplayName("save 테스트")
-    void save() {
+    void saveTest() {
         // given
         Member requestMember = new Member("test", "password");
         Member savedMember = memberRepository.save(requestMember);
@@ -109,7 +109,7 @@ class WishRepositoryTest {
 
     @Test
     @DisplayName("delete 테스트")
-    void delete() {
+    void deleteTest() {
         // given
         Member requestMember = new Member("test", "password");
         Member savedMember = memberRepository.save(requestMember);

--- a/src/test/java/gift/service/CategoryServiceTest.java
+++ b/src/test/java/gift/service/CategoryServiceTest.java
@@ -1,0 +1,145 @@
+package gift.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import gift.domain.category.dto.CategoryRequest;
+import gift.domain.category.dto.CategoryResponse;
+import gift.domain.category.entity.Category;
+import gift.domain.category.repository.CategoryRepository;
+import gift.domain.category.service.CategoryService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+    @InjectMocks
+    private CategoryService categoryService;
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Test
+    @DisplayName("카테고리 전체 조회 테스트")
+    void getAllCategoriesTest(){
+        List<Category> categoryList = Arrays.asList(new Category(1L,"name1", "color", "imageUrl", "description"),
+            new Category(2L,"name1", "color", "imageUrl", "description"));
+
+        int pageNo = 0;
+        int pageSize = 10;
+        Pageable pageable = PageRequest.of(pageNo, pageSize);
+        Page<Category> categoryPage =new PageImpl<>(categoryList,pageable, categoryList.size());
+
+        doReturn(categoryPage).when(categoryRepository).findAll(pageable);
+
+        Page<CategoryResponse> expected = categoryPage.map(this::entityToDto);
+
+        // when
+        Page<CategoryResponse> actual = categoryService.getAllCategories(pageNo, pageSize);
+
+        // then
+        assertAll(
+            () -> assertThat(actual).isNotNull(),
+            () -> IntStream.range(0, actual.getContent().size()).forEach(i -> {
+                assertThat(actual.getContent().get(i).getName())
+                    .isEqualTo(expected.getContent().get(i).getName());
+                assertThat(actual.getContent().get(i).getColor())
+                    .isEqualTo(expected.getContent().get(i).getColor());
+                assertThat(actual.getContent().get(i).getImageUrl())
+                    .isEqualTo(expected.getContent().get(i).getImageUrl());
+                assertThat(actual.getContent().get(i).getDescription())
+                    .isEqualTo(expected.getContent().get(i).getDescription());
+            })
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 테스트")
+    void createCategoryTest(){
+        // given
+        CategoryRequest request = new CategoryRequest("name", "color", "imageUrl", "description");
+
+        Category savedCategory = new Category(1L, request.getName(), request.getColor(), request.getImageUrl(), request.getDescription());
+
+        doReturn(savedCategory).when(categoryRepository).save(any());
+
+        CategoryResponse expected = entityToDto(savedCategory);
+
+        // when
+        CategoryResponse actual = categoryService.createCategory(request);
+
+        // then
+        assertAll(
+            () -> assertThat(actual.getId()).isEqualTo(expected.getId()),
+            () -> assertThat(actual.getName()).isEqualTo(expected.getName()),
+            () -> assertThat(actual.getColor()).isEqualTo(expected.getColor()),
+            () -> assertThat(actual.getImageUrl()).isEqualTo(expected.getImageUrl()),
+            () -> assertThat(actual.getDescription()).isEqualTo(expected.getDescription())
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 수정 테스트")
+    void updateCategory(){
+        // given
+        Long id = 1L;
+        CategoryRequest request = new CategoryRequest("update", "color", "imageUrl", "description");
+        Category savedCategory = spy(new Category(1L, "name", "color", "imageUrl", "description"));
+
+        doReturn(Optional.of(savedCategory)).when(categoryRepository).findById(any());
+        doNothing().when(savedCategory).updateAll(request.getName(), request.getColor(), request.getImageUrl(), request.getDescription());
+
+        Category updateCategory = new Category(1L, request.getName(), request.getColor(), request.getImageUrl(), request.getImageUrl());
+        doReturn(updateCategory).when(categoryRepository).save(any());
+
+        CategoryResponse expected = entityToDto(updateCategory);
+
+        // when
+        CategoryResponse actual = categoryService.updateCategory(id, request);
+
+        // then
+        assertAll(
+            () -> assertThat(actual.getId()).isEqualTo(expected.getId()),
+            () -> assertThat(actual.getName()).isEqualTo(expected.getName()),
+            () -> assertThat(actual.getColor()).isEqualTo(expected.getColor()),
+            () -> assertThat(actual.getImageUrl()).isEqualTo(expected.getImageUrl()),
+            () -> assertThat(actual.getDescription()).isEqualTo(expected.getDescription())
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 삭제 테스트")
+    void deleteCategory(){
+        Long id = 1L;
+        Category savedCategory = new Category(1L, "name", "color", "imageUrl", "description");
+
+        doReturn(Optional.of(savedCategory)).when(categoryRepository).findById(id);
+
+        // when
+        categoryService.deleteCategory(id);
+
+        // then
+        verify(categoryRepository, times(1)).delete(savedCategory);
+    }
+
+    private CategoryResponse entityToDto(Category category){
+        return new CategoryResponse(category.getId(), category.getName(), category.getColor(), category.getImageUrl(), category.getDescription());
+    }
+}

--- a/src/test/java/gift/service/CategoryServiceTest.java
+++ b/src/test/java/gift/service/CategoryServiceTest.java
@@ -97,7 +97,7 @@ class CategoryServiceTest {
 
     @Test
     @DisplayName("카테고리 수정 테스트")
-    void updateCategory(){
+    void updateCategoryTest(){
         // given
         Long id = 1L;
         CategoryRequest request = new CategoryRequest("update", "color", "imageUrl", "description");
@@ -126,7 +126,7 @@ class CategoryServiceTest {
 
     @Test
     @DisplayName("카테고리 삭제 테스트")
-    void deleteCategory(){
+    void deleteCategoryTest(){
         Long id = 1L;
         Category savedCategory = new Category(1L, "name", "color", "imageUrl", "description");
 

--- a/src/test/java/gift/service/MemberServiceTest.java
+++ b/src/test/java/gift/service/MemberServiceTest.java
@@ -33,7 +33,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("회원가입 테스트")
-    void register() {
+    void registerTest() {
         //given
         MemberRequest memberRequest = new MemberRequest("test@email.com", "password");
         Member savedMember = new Member(memberRequest.getEmail(), memberRequest.getPassword());
@@ -50,7 +50,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("로그인 성공 테스트")
-    void loginSuccess() {
+    void loginSuccessTest() {
         // given
         MemberRequest memberRequest = new MemberRequest("test@google.co.kr", "password");
         Member savedMember = new Member(memberRequest.getEmail(), memberRequest.getPassword());
@@ -67,7 +67,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("비밀번호 불일치 시 로그인 실패 테스트")
-    void loginFail() {
+    void loginFailTest() {
         // given
         MemberRequest memberRequest = new MemberRequest("test@google.co.kr", "wrongPassword");
         Member savedMember = new Member(memberRequest.getEmail(), "password");
@@ -81,15 +81,9 @@ class MemberServiceTest {
         assertThat(responseToken).isNull();
     }
 
-    public void deleteMember(Long id) {
-        Member member = memberRepository.findById(id)
-            .orElseThrow(() -> new EntityNotFoundException("not found Entity"));
-        memberRepository.delete(member);
-    }
-
     @Test
     @DisplayName("멤버 삭제 테스트")
-    void deleteMember() {
+    void deleteMemberTest() {
         // given
         Long id = 1L;
         Member savedMember = new Member(1L, "test@gmail.co.kr", "password");
@@ -103,7 +97,7 @@ class MemberServiceTest {
 
     @Test
     @DisplayName("토큰으로 저장된 멤버 가져오기 테스트")
-    void getMemberFromToken() {
+    void getMemberFromTokenTest() {
         // given
         String RequestToken = "jwtToken";
         Member savedMember = new Member("test@google.co.kr", "password");

--- a/src/test/java/gift/service/ProductServiceTest.java
+++ b/src/test/java/gift/service/ProductServiceTest.java
@@ -45,7 +45,7 @@ class ProductServiceTest {
 
     @Test
     @DisplayName("Id로 Product 조회 테스트")
-    void getProduct() {
+    void getProductTest() {
         // given
         Long id = 1L;
         Category category = new Category(1L, "test", "color", "image", "description");
@@ -68,7 +68,7 @@ class ProductServiceTest {
 
     @Test
     @DisplayName("모든 Product 조회 테스트")
-    void getAllProducts() {
+    void getAllProductsTest() {
         // given
         Category category1 = new Category(1L, "test", "color", "image", "description");
         Category category2 = new Category(2L, "test", "color", "image", "description");
@@ -106,7 +106,7 @@ class ProductServiceTest {
 
     @Test
     @DisplayName("product 저장 테스트")
-    void create() {
+    void createProductTest() {
         // given
         ProductRequest productRequest = new ProductRequest("test", 1000, "test.jpg", 1L);
         Category savedCategory = new Category(1L, "test", "color", "image", "description");
@@ -132,7 +132,7 @@ class ProductServiceTest {
 
     @Test
     @DisplayName("product 업데이트 테스트")
-    void updateProduct() {
+    void updateProductTest() {
         // given
         Long id = 1L;
         Category savedCategory = new Category(1L, "test", "color", "image", "description");
@@ -162,7 +162,7 @@ class ProductServiceTest {
 
     @Test
     @DisplayName("product 삭제 테스트")
-    void delete() {
+    void deleteProductTest0() {
         // given
         Long id = 1L;
         Category savedCategory = new Category(1L, "test", "color", "image", "description");

--- a/src/test/java/gift/service/WishServiceTest.java
+++ b/src/test/java/gift/service/WishServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import gift.domain.category.entity.Category;
 import gift.domain.wishlist.dto.WishRequest;
 import gift.domain.member.entity.Member;
 import gift.domain.product.entity.Product;
@@ -49,8 +50,10 @@ class WishServiceTest {
         // given
         Member savedMember = new Member(1L, "email@google.co.kr", "password");
 
-        Product product1 = new Product("product1", 1000, "product1.jpg");
-        Product product2 = new Product("product2", 2000, "product2.jpg");
+        Category savedCategory1 = new Category(1L, "test", "color", "image", "description");
+        Category savedCategory2 = new Category(2L, "test", "color", "image", "description");
+        Product product1 = new Product("product1", 1000, "product1.jpg",savedCategory1);
+        Product product2 = new Product("product2", 2000, "product2.jpg",savedCategory2);
 
         Wish wish1 = new Wish(savedMember, product1);
         Wish wish2 = new Wish(savedMember, product2);
@@ -87,8 +90,8 @@ class WishServiceTest {
         WishRequest wishRequest = new WishRequest(1L, 1L);
 
         Member savedMember = new Member(1L, "email@google.com", "password");
-        Product savedProduct = new Product(1L, "test", 1000, "test.jpg");
-        ;
+        Category savedCategory = new Category(1L, "test", "color", "image", "description");
+        Product savedProduct = new Product(1L, "test", 1000, "test.jpg", savedCategory);
 
         Wish saveWish = new Wish(savedMember, savedProduct);
         WishResponse expected = entityToDto(saveWish);
@@ -113,7 +116,8 @@ class WishServiceTest {
     void deleteWish() {
         Long id = 1L;
         Member savedMember = new Member(1L, "email@google.co.kr", "password");
-        Product savedProduct = new Product(1L, "test", 1000, "test.jpg");
+        Category savedCategory = new Category(1L, "test", "color", "image", "description");
+        Product savedProduct = new Product(1L, "test", 1000, "test.jpg", savedCategory);
 
         Wish wish = new Wish(savedMember, savedProduct);
 

--- a/src/test/java/gift/service/WishServiceTest.java
+++ b/src/test/java/gift/service/WishServiceTest.java
@@ -103,7 +103,7 @@ class WishServiceTest {
         doReturn(saveWish).when(wishRepository).save(any(Wish.class));
 
         // when
-        WishResponse actual = wishService.addWish(wishRequest);
+        WishResponse actual = wishService.createWish(wishRequest);
 
         // then
         assertThat(actual.getMemberId()).isEqualTo(expected.getMemberId());

--- a/src/test/java/gift/service/WishServiceTest.java
+++ b/src/test/java/gift/service/WishServiceTest.java
@@ -46,7 +46,7 @@ class WishServiceTest {
 
     @Test
     @DisplayName("getWishesByMember 테스트")
-    void getWishesByMember() {
+    void getWishesByMemberTest() {
         // given
         Member savedMember = new Member(1L, "email@google.co.kr", "password");
 
@@ -85,7 +85,7 @@ class WishServiceTest {
 
     @Test
     @DisplayName("위시 리스트 추가 테스트")
-    void addWish() {
+    void createWishTest() {
         // given
         WishRequest wishRequest = new WishRequest(1L, 1L);
 
@@ -113,7 +113,7 @@ class WishServiceTest {
 
     @Test
     @DisplayName("위시 리시트 삭제 테스트")
-    void deleteWish() {
+    void deleteWishTest() {
         Long id = 1L;
         Member savedMember = new Member(1L, "email@google.co.kr", "password");
         Category savedCategory = new Category(1L, "test", "color", "image", "description");


### PR DESCRIPTION
매번 정성스럽게 코드 리뷰 달아주셔서 감사합니다!!

# 진행
1. 카테고리 관련 entity, dto, repository, service, controller 작성
2. Product 와 Category 연관 관계 매핑 (N:1) 설정
3. 카테고리 test 작성
4. E2E 테스트 관련 테스트 격리 @DirtiesContext를 사용해서 진행

# 질문
1. WishControllerTest -> deleteWishTest() 안에서 Wish wish = new Wish(memberService.getMemberFromToken(token), product); 를 실행할 때, 지연 로딩에 의한 초기화 오류가 발생하였습니다. 실제 Service에서는 잘 실행되던 것이 test에서는 오류가 발생하니 좀 당황했습니다. GPT로 이유를 찾아보니 @SpringBootContext에서 RANDOM_PORT를 사용하면 테스트 실행과 요청을 처리하는 서버가 다른 쓰레드에서 실행돼서 하나의 트랜잭션으로 묶이지 않아 지연 로딩할 때, 엔티티를 가져온 세션이 닫혀 초기화를 시켜줄 수 없기 때문에 발생했다고 나왔습니다. 
하지만 제 코드를 살펴보니 `Wish wish = new Wish(memberService.getMemberFromToken(token), product);` 에서 에러가 발생하는데 저는 이 부분을 테스트 쓰레드에서 실행되는 것으로 이해했습니다. 그리고  `restTemplate`으로 보낸 요청이 서버 쓰레드에서 처리되는 것으로 이해했습니다. 따라서 메서드 시작부터` new Wish()`까지는 테스트 쓰레드에서 실행되고 하나의 트랙잭션으로 묶였으므로 에러 발생 지점까지는 `restTemplate` 을 사용하지 않았기 때문에 GPT가 말한 요청을 처리하는 서버와는 상관이 없다고 생각했습니다. 제가 이해한 게 맞는 지 궁금합니다. 만약 제가 생각한 게 맞다면 원인 또한 뭔지 궁금합니다!

이 부분에서 대해서는 일단 fetch 전략을 EAGER로 바꿔서 해결했는데 EAGER로 바뀐 경우 성능이 안 좋아지는 단점이 있어서 추후에 공부해서 해결하도록 하겠습니다!   