### PR TITLE
경북대 BE_이상희 4주차 과제 (3 + 4단계)

### DIFF
--- a/src/main/java/gift/product/domain/ProductOption.java
+++ b/src/main/java/gift/product/domain/ProductOption.java
@@ -58,4 +58,11 @@ public class ProductOption {
     public boolean isSameName(String name) {
         return this.getName().equals(name);
     }
+
+    public void buy(int quantity) {
+        if (this.quantity < quantity) {
+            throw new IllegalArgumentException("Not enough quantity");
+        }
+        this.quantity -= quantity;
+    }
 }

--- a/src/main/java/gift/product/persistence/ProductOptionRepository.java
+++ b/src/main/java/gift/product/persistence/ProductOptionRepository.java
@@ -1,12 +1,19 @@
 package gift.product.persistence;
 
 import gift.product.domain.ProductOption;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
     Optional<ProductOption> findByProductIdAndId(Long productId, Long id);
 
     List<ProductOption> findByProductId(Long productId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select po from ProductOption po where po.product.id = :productId and po.id = :id")
+    Optional<ProductOption> findByProductIdAndIdForUpdate(Long productId, Long id);
 }

--- a/src/main/java/gift/product/service/ProductOptionService.java
+++ b/src/main/java/gift/product/service/ProductOptionService.java
@@ -86,8 +86,7 @@ public class ProductOptionService {
 
     @Transactional
     public void buyProduct(final Long productId, final Long optionId, final int quantity) {
-        var productOption = productOptionRepository.findByProductIdAndIdForUpdate(productId, optionId)
-                .orElseThrow(() -> ProductOptionNotFoundException.of(productId, optionId));
+        var productOption = getExistsProductOptionForUpdate(productId, optionId);
 
         productOption.buy(quantity);
     }

--- a/src/main/java/gift/product/service/ProductOptionService.java
+++ b/src/main/java/gift/product/service/ProductOptionService.java
@@ -51,9 +51,8 @@ public class ProductOptionService {
     }
 
     @Transactional
-    public void modifyProductOption(Long productId, Long optionId,
-                                    ProductOptionCommand productOptionCommand) {
-        var productOption = getExistsProductOption(productId, optionId);
+    public void modifyProductOption(Long productId, Long optionId, ProductOptionCommand productOptionCommand) {
+        var productOption = getExistsProductOptionForUpdate(productId, optionId);
 
         productOption.modify(productOptionCommand.name(), productOptionCommand.quantity());
     }
@@ -69,10 +68,9 @@ public class ProductOptionService {
     public List<ProductOptionInfo> getAllProductOptions(Long productId) {
         var productOptions = productOptionRepository.findByProductId(productId);
 
-        var response = productOptions.stream()
+        return productOptions.stream()
                 .map(ProductOptionInfo::from)
                 .toList();
-        return response;
     }
 
     @Transactional
@@ -86,11 +84,25 @@ public class ProductOptionService {
         productOptionRepository.delete(option);
     }
 
+    @Transactional
+    public void buyProduct(final Long productId, final Long optionId, final int quantity) {
+        var productOption = productOptionRepository.findByProductIdAndIdForUpdate(productId, optionId)
+                .orElseThrow(() -> ProductOptionNotFoundException.of(productId, optionId));
+
+        productOption.buy(quantity);
+    }
+
     private ProductOption getExistsProductOption(Long productId, Long optionId) {
         var option = productOptionRepository.findByProductIdAndId(productId, optionId)
                 .orElseThrow(() -> ProductOptionNotFoundException.of(productId, optionId));
 
         return option;
+    }
+
+    private ProductOption getExistsProductOptionForUpdate(Long productId, Long optionId) {
+
+        return productOptionRepository.findByProductIdAndIdForUpdate(productId, optionId)
+                .orElseThrow(() -> ProductOptionNotFoundException.of(productId, optionId));
     }
 
     private void validateDuplicatedProductName(Long productId, List<String> names) {

--- a/src/main/java/gift/product/service/ProductService.java
+++ b/src/main/java/gift/product/service/ProductService.java
@@ -33,7 +33,7 @@ public class ProductService {
         Category category = categoryRepository.findByName(productRequest.categoryName())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리입니다."));
         Product product = productRequest.toEntity(category);
-        var newProduct = productRepository.save(product);// 이렇게 하지않으면, Stream에서 사용할 수 없다... 어떻게 해야하나
+        var newProduct = productRepository.save(product);
 
         return newProduct.getId();
     }

--- a/src/main/java/gift/product/service/facade/ProductFacade.java
+++ b/src/main/java/gift/product/service/facade/ProductFacade.java
@@ -24,7 +24,6 @@ public class ProductFacade {
     @Transactional
     public Long saveProduct(ProductCommand productCommand, List<ProductOptionCommand> productOptionCommands) {
         var productId = productService.saveProduct(productCommand);
-        log.info("Product Created");
         productOptionService.createProductOptions(productId, productOptionCommands);
         return productId;
     }

--- a/src/test/java/gift/product/service/ProductOptionLockTest.java
+++ b/src/test/java/gift/product/service/ProductOptionLockTest.java
@@ -1,0 +1,70 @@
+package gift.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gift.product.domain.Category;
+import gift.product.domain.Product;
+import gift.product.domain.ProductOption;
+import gift.product.persistence.CategoryRepository;
+import gift.product.persistence.ProductOptionRepository;
+import gift.product.persistence.ProductRepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class ProductOptionLockTest {
+    @Autowired
+    private ProductOptionRepository productOptionRepository;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ProductOptionService productOptionService;
+
+    @BeforeEach
+    void setUp() {
+        Category category = new Category("name", "test", "Test", "Test");
+        Product product = new Product("name", 1000, "URL", category);
+        ProductOption productOption = new ProductOption("test", 100, product);
+
+        categoryRepository.save(category);
+        productRepository.save(product);
+        productOptionRepository.save(productOption);
+    }
+
+    @Test
+    @DisplayName("ProductOptionService 동시성 테스트")
+    void productOptionServiceBuyProductTest() throws InterruptedException {
+        //given
+        final Integer THREAD_CNT = 77;
+        final Long productId = 1L;
+        final Long optionId = 1L;
+
+        //when
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
+        CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
+        for (int i = 0; i < THREAD_CNT; i++) {
+            executorService.submit(() -> {
+                try {
+                    productOptionService.buyProduct(productId, optionId, 1);
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        var option = productOptionRepository.findByProductIdAndId(productId, optionId).orElseThrow();
+        assertThat(option.getQuantity()).isEqualTo(23);
+    }
+}


### PR DESCRIPTION
**구현기능**
수량 차감 기능을 추가하였습니다.

**질문사항**
1. Product의 Option을 구매할 때 추후 결제로직 같은 부분이 추가된다고 생각했을 때, ProductOptionController를 호출하는 것이 아닌,  새로운 컨트롤러 및 서비스를 만드는게 좋다고 생각하는데 어떻게 생각하시는지 궁금합니다.

2. 낙관적락 VS 비관적락
현재는 서버가 한대이지만, 추후 스케일업을 고려해 비관적락을 적용하였습니다.
비관적락을 사용한 이유는 낙관적 락의 경우 경합 상태가 발생할 경우 retry로 인해 나중에 들어온 사용자가 먼저 구매되는 것을 막기 위해서 사용했습니다.
이 때 비관적락을 사용하면, 데드락의 발생가능성이 높아지고, 확장성이 저하된다고 알고있는데 비관적락보다 낙관적 락을 사용하는게 좋을까요?
또, 낙관적락을 사용할 때 먼저 구매요청을 한 사용자가 먼저 구매되기 위해서는 어떤 로직을 추가하는게 좋을까요?