### PR TITLE
경북대 BE_석혜원 4주차 과제 (4단계)

### DIFF
--- a/src/main/java/gift/api/member/MemberService.java
+++ b/src/main/java/gift/api/member/MemberService.java
@@ -3,8 +3,8 @@ package gift.api.member;
 import gift.global.exception.ForbiddenMemberException;
 import gift.global.exception.UnauthorizedMemberException;
 import gift.global.utils.JwtUtil;
-import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberService {

--- a/src/main/java/gift/api/option/OptionRepository.java
+++ b/src/main/java/gift/api/option/OptionRepository.java
@@ -1,11 +1,20 @@
 package gift.api.option;
 
 import gift.api.option.domain.Option;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OptionRepository extends JpaRepository<Option, Long> {
-    List<Option> findAllByProductId(Long id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select o from Option o where o.id = :id")
+    Optional<Option> findByIdWithPessimisticWrite(Long id);
+
+    List<Option> findAllByProductId(Long productId);
 }

--- a/src/main/java/gift/api/option/OptionService.java
+++ b/src/main/java/gift/api/option/OptionService.java
@@ -7,10 +7,10 @@ import gift.api.option.dto.OptionResponse;
 import gift.api.product.Product;
 import gift.api.product.ProductRepository;
 import gift.global.exception.NoSuchEntityException;
-import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class OptionService {
@@ -42,7 +42,7 @@ public class OptionService {
 
     @Transactional
     public void subtract(Long id, Integer quantity) {
-        Option option = optionRepository.findById(id)
+        Option option = optionRepository.findByIdWithPessimisticWrite(id)
             .orElseThrow(() -> new NoSuchEntityException("option"));
         option.subtract(quantity);
     }

--- a/src/main/java/gift/api/product/ProductService.java
+++ b/src/main/java/gift/api/product/ProductService.java
@@ -5,13 +5,13 @@ import gift.api.category.CategoryRepository;
 import gift.api.product.dto.ProductRequest;
 import gift.api.product.dto.ProductResponse;
 import gift.global.exception.NoSuchEntityException;
-import jakarta.transaction.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ProductService {

--- a/src/main/java/gift/api/wishlist/WishService.java
+++ b/src/main/java/gift/api/wishlist/WishService.java
@@ -10,7 +10,6 @@ import gift.api.wishlist.dto.WishAddUpdateRequest;
 import gift.api.wishlist.dto.WishDeleteRequest;
 import gift.api.wishlist.dto.WishResponse;
 import gift.global.exception.NoSuchEntityException;
-import jakarta.transaction.Transactional;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class WishService {

--- a/src/test/java/gift/api/option/OptionIntegrationTest.java
+++ b/src/test/java/gift/api/option/OptionIntegrationTest.java
@@ -1,0 +1,65 @@
+package gift.api.option;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import gift.api.category.Category;
+import gift.api.category.CategoryRepository;
+import gift.api.option.domain.Option;
+import gift.api.product.Product;
+import gift.api.product.ProductRepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class OptionIntegrationTest {
+
+    @Autowired
+    private OptionRepository optionRepository;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private OptionService optionService;
+
+    @BeforeEach
+    void setup() {
+        Category category = new Category("category", "#FFFFFF", "url", "2상2는 바보다.");
+        categoryRepository.save(category);
+        Product product = new Product(category, "product", 1000, "url");
+        productRepository.save(product);
+        Option option = new Option(product, "option", 100);
+        optionRepository.save(option);
+    }
+
+    @Test
+    @DisplayName("옵션_수량_차감_동시성_테스트")
+    void concurrentSubtract() throws InterruptedException {
+        // given
+        final int threadCount = 100;
+        final ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    optionService.subtract(4L, 1);
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+        countDownLatch.await();
+
+        // then
+        assertThat(optionRepository.findById(4L).get().getQuantity())
+            .isEqualTo(0);
+    }
+}

--- a/src/test/java/gift/api/option/OptionServiceTest.java
+++ b/src/test/java/gift/api/option/OptionServiceTest.java
@@ -33,7 +33,7 @@ class OptionServiceTest {
     private OptionService optionService;
 
     @Test
-    @DisplayName(value = "옵션_조회_테스트")
+    @DisplayName("옵션_조회_테스트")
     void getOptions() {
         // given
         var productId = 1L;
@@ -49,7 +49,7 @@ class OptionServiceTest {
     }
 
     @Test
-    @DisplayName(value = "정상_옵션_추가_테스트")
+    @DisplayName("정상_옵션_추가_테스트")
     void add() {
         // given
         var product = mock(Product.class);
@@ -66,7 +66,7 @@ class OptionServiceTest {
     }
 
     @Test
-    @DisplayName(value = "중복_이름_옵션_추가_테스트")
+    @DisplayName("중복_이름_옵션_추가_테스트")
     void addRedundantOption() {
         // given
         var product = mock(Product.class);
@@ -83,7 +83,7 @@ class OptionServiceTest {
     }
 
     @Test
-    @DisplayName(value = "정상_옵션_수량_차감_테스트")
+    @DisplayName("정상_옵션_수량_차감_테스트")
     void subtract() {
         // given
         var before = 100;

--- a/src/test/java/gift/api/option/domain/OptionTest.java
+++ b/src/test/java/gift/api/option/domain/OptionTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 class OptionTest {
 
     @Test
-    @DisplayName(value = "정상_옵션_수량_차감_테스트")
+    @DisplayName("정상_옵션_수량_차감_테스트")
     void subtract() {
         // given
         var before = 100;

--- a/src/test/java/gift/api/option/domain/OptionsTest.java
+++ b/src/test/java/gift/api/option/domain/OptionsTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 class OptionsTest {
 
     @Test
-    @DisplayName(value = "중복된_이름의_옵션_추가_테스트")
+    @DisplayName("중복된_이름의_옵션_추가_테스트")
     void validateUniqueName() {
         // given
         var product = mock(Product.class);


### PR DESCRIPTION
3단계 피드백해주신 내용은 5주차 과제에서 반영하도록 하겠습니다!

#### 궁금한 점
`OptionRepository`에서 `findById()`를 오버라이드하여 lock을 걸었을 때, 기존에 설정되어 있는 read only 옵션으로 인해 `OptionIntegrationTest`의 동시성 테스트가 실패하는 것을 보았습니다.
```
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    @Transactional
    Optional<Option> findById(Long id);
```
```
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    @Query("select o from Option o where o.id = :id")
    Optional<Option> findByIdWithPessimisticWrite(Long id);
```
그 후 위의 두 가지 방식으로 테스트가 통과하는 것을 확인했는데, 아래의 방식이 더 권장되는 방식일까요? 위의 방식에서 read only 옵션을 끄는 것이 적절하지 않다는 생각이 드는데, 정확한 이유가 궁금합니다!